### PR TITLE
support [test] and [live] groups in ~/.stripecli config file

### DIFF
--- a/lib/stripe/cli/command.rb
+++ b/lib/stripe/cli/command.rb
@@ -4,7 +4,7 @@ module Stripe
   module CLI
     class Command < Thor
       class_option :key, :aliases => :k
-
+      class_option :mode, :aliases => :m
       protected
 
       def api_key
@@ -13,7 +13,13 @@ module Stripe
 
       def stored_api_key
         if File.exists?(config_file)
-          ParseConfig.new(config_file)['key']
+          config = ParseConfig.new(config_file)
+          groups = config.get_groups
+          if groups.empty?
+            config['key']
+          else
+            config[ options.delete(:mode)||groups[0] ]['key']
+          end
         end
       end
 


### PR DESCRIPTION
Hi there!

very nice cli you got here.  This code just makes use of the "groups" support thats built into the ParseConfig gem to allow for predefining both `test` and `live` secret keys in your `~/.stripecli` config file.  stripe-cli will then use the first group, by default, or the group specified on the command line with the `--mode` parameter, like `--mode=live`.  config files with no groups will continue to work as before, however you can also define one like this:

![stripecli](https://f.cloud.github.com/assets/1504753/793087/fb3e7084-ebdd-11e2-997b-29eae8c2156b.png)
