### PR TITLE
Duration option was not working in non-interactive mode

### DIFF
--- a/lib/stripe/cli/commands/coupons.rb
+++ b/lib/stripe/cli/commands/coupons.rb
@@ -28,7 +28,7 @@ module Stripe
         option :id
         option :percent_off, :type => :numeric
         option :amount_off, :type => :numeric
-        option :duration, :enum => [ :forever, :once, :repeating ]
+        option :duration, :enum => %w( forever once repeating )
         option :redeem_by, :desc => "coupon will no longer be accepted after this date."
         option :max_redemptions, :type => :numeric
         option :duration_in_months


### PR DESCRIPTION
I changed one line to use %w( foo bar baz ) style like you have in the rest of the commands. But, I gotta tell you, this is the first time I ever touch ruby so I don't know if I was just doing something stupid where it wasn't working for me.

I was trying to create coupons in our stripe account like this: `stripe coupons create --id=500-startups-yearly --percent-off=50 --metadata=description:You\ get\ this\ perk\ for\ being\ part\ of\ the\ 500\ Startups\ Familia url:'https://vonjour.com/#/500-startups-yearly' --duration=forever --redeem-by=`
but it would say that --duration was expecting one of forever, once, repeating, but got forever. 

With this change, it seems to work in both interactive and non-interactive mode. 
